### PR TITLE
Update devSVG.c to add space after namespace in attributes

### DIFF
--- a/src/devSVG.c
+++ b/src/devSVG.c
@@ -287,7 +287,7 @@ static Rboolean SVG_Open(pDevDesc dd, SVGDesc *ptd) {
 
 	fprintf(ptd->texfp, "<svg ");
 	if (ptd->useNS)
-	  fprintf(ptd->texfp, "xmlns=\"http://www.w3.org/2000/svg\"");
+	  fprintf(ptd->texfp, "xmlns=\"http://www.w3.org/2000/svg\" ");
 
 	fprintf(ptd->texfp, "width=\"%.2f\" height=\"%.2f\" ",
 			in2dots(ptd->width), in2dots(ptd->height));


### PR DESCRIPTION
add space following namespace so following attributes properly formed.  currently we get

```
<?xml version="1.0" encoding="UTF-8"?>
<svg xmlns="http://www.w3.org/2000/svg"width="722.70" height="578.16" viewBox="0,0,722.70,578.16">
```