### PR TITLE
add function for quick visual testing

### DIFF
--- a/R/htmlSVG.R
+++ b/R/htmlSVG.R
@@ -1,0 +1,25 @@
+#' Run plotting code and view svg in RStudio Viewer or web broswer.
+#'
+#' This is useful primarily for testing. Requires the \code{htmltools}
+#' package.
+#'
+#' @param code Plotting code to execute.
+#' @param ... Other arguments passed on to \code{\link{devSVG}}.
+#' @export
+#' @examples
+#' if (require("htmltools")) {
+#'   htmlSVG(plot(1, axes = FALSE))
+#' }
+htmlSVG <- function(code, ...) {
+  tmp <- tempfile()
+  devSVG(tmp, width = 5, height = 5, useNS = FALSE, ...)
+  tryCatch(code,
+    finally = dev.off()
+  )
+
+  htmltools::browsable(
+    htmltools::HTML(paste0(readLines(tmp),collapse="\n"))
+  )
+}
+
+


### PR DESCRIPTION
Similar to #10 quick and easy visual tests via `htmltools::browsable` mightbe a nice feature.  Add a function `htmlSVG` modelled after `xmlSVG`.