### PR TITLE
Specify fill/stroke opacity separately

### DIFF
--- a/src/devSVG.c
+++ b/src/devSVG.c
@@ -139,11 +139,10 @@ void write_attr_col(FILE* f, const char* attr, unsigned int col) {
   if (col == NA_INTEGER || alpha == 0) {
     fprintf(f, " %s='none'", attr);
     return;
-  } else if (alpha == 255) {
-    fprintf(f, " %s='#%02X%02X%02X'", attr, R_RED(col), R_GREEN(col), R_BLUE(col));
   } else {
-    fprintf(f, " %s='rgba(%i, %i, %i, %0.2f)'", attr, R_RED(col), R_GREEN(col),
-      R_BLUE(col), alpha / 255.0);
+    fprintf(f, " %s='#%02X%02X%02X'", attr, R_RED(col), R_GREEN(col), R_BLUE(col));
+    if (alpha != 255)
+      fprintf(f, " %s-opacity='%0.2f'", attr, alpha / 255.0);
   }
 }
 

--- a/tests/testthat/test-points.R
+++ b/tests/testthat/test-points.R
@@ -16,8 +16,10 @@ test_that("points get alpha stroke and fill given stroke and fill", {
     points(0.5, 0.5, pch = 21, col = rgb(1, 0, 0, 0.1), bg = rgb(0, 0, 1, 0.1), cex = 20)
   })
   circle <- xml_find_all(x, ".//circle")
-  expect_equal(xml_attr(circle, "stroke"), "rgba(255, 0, 0, 0.10)")
-  expect_equal(xml_attr(circle, "fill"), "rgba(0, 0, 255, 0.10)")
+  expect_equal(xml_attr(circle, "stroke"), rgb(1, 0, 0))
+  expect_equal(xml_attr(circle, "stroke-opacity"), "0.10")
+  expect_equal(xml_attr(circle, "fill"), rgb(0, 0, 1))
+  expect_equal(xml_attr(circle, "fill-opacity"), "0.10")
 })
 
 test_that("points are given stroke and fill", {


### PR DESCRIPTION
Inkscape doesn't seem to understand rgba values. It shows solid black instead.

https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Fills_and_Strokes says
> for compatibility with other viewers, it's often best to specify the fill/stroke opacity separately