### PR TITLE
add function editSVG to open the svg in OS default SVG editor/viewer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,4 +22,5 @@
 * Supports all line dashing (#15)
 
 * Helper functions `xmlSVG()` and `htmlSVG()` make it easier to view generated
-  SVG, either as raw XML or in RStudio/the browser.
+  SVG, either as raw XML or in RStudio/the browser. `editSVG` opens the SVG in
+  the OS/system default SVG viewer or editor.

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,5 +22,6 @@
 * Supports all line dashing (#15)
 
 * Helper functions `xmlSVG()` and `htmlSVG()` make it easier to view generated
-  SVG, either as raw XML or in RStudio/the browser. `editSVG` opens the SVG in
-  the OS/system default SVG viewer or editor.
+  SVG, either as raw XML or in RStudio/the browser. `editSVG()` opens the SVG
+  in the OS/system default SVG viewer or editor.
+  

--- a/R/inlineSVG.R
+++ b/R/inlineSVG.R
@@ -1,4 +1,5 @@
-inlineSVG <- function(code, ..., width = NA, height = NA, path = tempfile()) {
+inlineSVG <- function(code, ..., width = NA, height = NA,
+                      path = tempfile(fileext = ".svg")) {
   dim <- plot_dim(c(width, height))
 
   devSVG(path, width = dim[1], height = dim[2], ...)

--- a/R/inlineSVG.R
+++ b/R/inlineSVG.R
@@ -58,7 +58,7 @@ xmlSVG <- function(code, ...) {
 #' @export
 #' @examples
 #' editSVG(plot(1:10))
-#' editSVG(hist(rnorm(100)))
+#' editSVG(contour(volcano))
 
 editSVG <- function(code, ...) {
   tmp <- inlineSVG(code, ...)

--- a/R/inlineSVG.R
+++ b/R/inlineSVG.R
@@ -48,3 +48,18 @@ xmlSVG <- function(code, ...) {
   xml2::read_xml(plot)
 }
 
+#' Run plotting code and open svg in OS/system default svg viewer or editor.
+#'
+#' This is useful primarily for testing or post-processing the SVG.
+#'
+#' @param code Plotting code to execute.
+#' @param ... Other arguments passed on to \code{\link{devSVG}}.
+#' @export
+#' @examples
+#' editSVG(plot(1:10))
+#' editSVG(hist(rnorm(100)))
+
+editSVG <- function(code, ...) {
+  tmp <- inlineSVG(code, ...)
+  system(sprintf("open %s", shQuote(tmp)))
+}


### PR DESCRIPTION
I thought it might be nice to have a function to open the SVG in the default OS SVG viewer/editor, such as Illustrator, Sketch, or Inkscape for both testing, but also post-processing.  I modelled the function on `xmlSVG` and `htmlSVG`. I don't have Linux/Apple to test, but it seems `open` works in all the OS.

![rsvgdevice_editsvg](https://cloud.githubusercontent.com/assets/837910/9733009/d05b2ca0-55ed-11e5-80c4-4e441da1d1e9.gif)
