### PR TITLE
fix symbol display

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ warnings_are_errors: true
 
 r_github_packages:
   - jimhester/covr
+  - davidgohel/gdtools
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R: c(
   person("Matthieu", "Decorde", , "matthieu.decorde@ens-lyon.fr", c("aut", "cre")),
   person("Vaudor", "Lise", , "lise.vaudor@ens-lyon.fr", "aut"),
   person("Hadley", "Wickham", , "hadley@rstudio.com", "aut"),
-  person("David", "Gohel", role = "ctb", comment = "Line dashing code"),
+  person("David", "Gohel", role = "ctb", comment = "Line dashing code and raster code"),
   person("Håkon", "Malmedal", role = "ctb", comment = "Opacity code"),
   person("RStudio", role = "cph")
   )

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,3 +23,5 @@
 
 * Helper functions `xmlSVG()` and `htmlSVG()` make it easier to view generated
   SVG, either as raw XML or in RStudio/the browser.
+
+* Supports for rasters (#2)

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -170,8 +170,10 @@ static void svg_new_page(const pGEcontext gc, pDevDesc dd) {
     fputs("<?xml version='1.0' encoding='UTF-8' ?>\n", svgd->file);
 
   fputs("<svg ", svgd->file);
-  if (svgd->standalone)
+  if (svgd->standalone){
     fputs("xmlns='http://www.w3.org/2000/svg' ", svgd->file);
+    fputs("xmlns:xlink='http://www.w3.org/1999/xlink' ", svgd->file);//http://www.w3.org/wiki/SVG_Links
+  }
 
   fprintf(svgd->file, "viewBox='0 0 %.2f %.2f'>\n", dd->right, dd->bottom);
 
@@ -326,13 +328,12 @@ static void svg_raster(unsigned int *raster, int w, int h,
   write_attr_dbl(svgd->file, "height", height);
   write_attr_dbl(svgd->file, "x", x);
   write_attr_dbl(svgd->file, "y", y - height);
+
   if( rot != 0 ){
     fprintf(svgd->file, " transform='rotate(%0.0f,%.2f,%.2f)'", -1.0 * rot, x, y);
   }
 
   fprintf(svgd->file, " xlink:href='data:image/png;base64,%s'", base64_str.c_str());
-  if (svgd->standalone) fputs( " xmlns:xlink='http://www.w3.org/1999/xlink'", svgd->file);
-
   fputs( "/>", svgd->file);
 }
 

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -56,8 +56,9 @@ inline bool is_italic(int face) {
   return face == 3 || face == 4;
 }
 
-inline std::string fontname(const char* family_) {
+inline std::string fontname(const char* family_, int face) {
   std::string family(family_);
+  if( face == 5 ) return "symbol";
 
   if (family == "mono") {
     return "courier";
@@ -140,7 +141,7 @@ static void svg_metric_info(int c, const pGEcontext gc, double* ascent,
     str[1] = '\0';
   }
 
-  gdtools::context_set_font(svgd->cc, fontname(gc->fontfamily),
+  gdtools::context_set_font(svgd->cc, fontname(gc->fontfamily, gc->fontface),
     gc->cex * gc->ps, is_bold(gc->fontface), is_italic(gc->fontface));
   FontMetric fm = gdtools::context_extents(svgd->cc, std::string(str));
 
@@ -230,7 +231,7 @@ static void svg_polygon(int n, double *x, double *y, const pGEcontext gc,
 static double svg_strwidth(const char *str, const pGEcontext gc, pDevDesc dd) {
   SVGDesc *svgd = (SVGDesc*) dd->deviceSpecific;
 
-  gdtools::context_set_font(svgd->cc, fontname(gc->fontfamily),
+  gdtools::context_set_font(svgd->cc, fontname(gc->fontfamily, gc->fontface),
     gc->cex * gc->ps, is_bold(gc->fontface), is_italic(gc->fontface));
   FontMetric fm = gdtools::context_extents(svgd->cc, std::string(str));
 
@@ -283,7 +284,7 @@ static void svg_text(double x, double y, const char *str, double rot,
   if (gc->col != -16777216) // black
     write_attr_col(svgd->file, "fill", gc->col);
 
-  std::string font = fontname(gc->fontfamily);
+  std::string font = fontname(gc->fontfamily, gc->fontface);
   write_attr_str(svgd->file, "font-family", font.c_str());
 
   fputs(">", svgd->file);

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -321,17 +321,19 @@ static void svg_raster(unsigned int *raster, int w, int h,
 
   std::string base64_str = gdtools::raster_to_str(raster_, w, h, width, height, (Rboolean) interpolate);
 
-  fprintf(svgd->file, "<image x='%.2f' y='%.2f' ", x, y - height );
-  fprintf(svgd->file, "width='%.2f' height='%.2f' ", width, height);
-
-  if (fabs(rot)>0.001) {
-    fprintf(svgd->file, "transform='rotate(%0.0f,%0.0f,%0.0f)' ", -1.0 * rot, x, y );
+  fputs("<image", svgd->file);
+  write_attr_dbl(svgd->file, "width", width);
+  write_attr_dbl(svgd->file, "height", height);
+  write_attr_dbl(svgd->file, "x", x);
+  write_attr_dbl(svgd->file, "y", y - height);
+  if( rot != 0 ){
+    fprintf(svgd->file, " transform='rotate(%0.0f,%0.0f,%0.0f)'", -1.0 * rot, x, y);
   }
-  fprintf(svgd->file, "xlink:href='data:image/png;base64,%s'", base64_str.c_str());
+
+  fprintf(svgd->file, " xlink:href='data:image/png;base64,%s'", base64_str.c_str());
   if (svgd->standalone) fputs( " xmlns:xlink='http://www.w3.org/1999/xlink'", svgd->file);
+
   fputs( "/>", svgd->file);
-
-
 }
 
 

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -327,7 +327,7 @@ static void svg_raster(unsigned int *raster, int w, int h,
   write_attr_dbl(svgd->file, "x", x);
   write_attr_dbl(svgd->file, "y", y - height);
   if( rot != 0 ){
-    fprintf(svgd->file, " transform='rotate(%0.0f,%0.0f,%0.0f)'", -1.0 * rot, x, y);
+    fprintf(svgd->file, " transform='rotate(%0.0f,%.2f,%.2f)'", -1.0 * rot, x, y);
   }
 
   fprintf(svgd->file, " xlink:href='data:image/png;base64,%s'", base64_str.c_str());

--- a/tests/testthat/test-raster.R
+++ b/tests/testthat/test-raster.R
@@ -1,0 +1,11 @@
+context("raster")
+
+test_that("raster exists", {
+  x <- xmlSVG({
+    r <- as.raster(matrix(hcl(0, 80, seq(40, 80, 10)), nrow = 5, ncol = 4))
+    plot(r)
+  })
+
+  img <- xml_attr(xml_find_all(x, ".//image"), "xlink:href")
+  expect_less_than(22, nchar(img) )
+})

--- a/tests/testthat/test-text.R
+++ b/tests/testthat/test-text.R
@@ -89,3 +89,21 @@ test_that("font sets weight/style", {
   text <- xml_find_all(x, ".//text")
   expect_equal(xml_attr(text, "font-family"), c("Times New Roman", "Arial", "courier"))
 })
+
+test_that("a symbol has width greater than 0", {
+  xmlSVG({
+    plot(c(0,2), c(0,2), type = "n")
+    strw <- strwidth(expression(symbol("\042")))
+  })
+  expect_less_than(.Machine$double.eps, strw)
+})
+
+test_that("symbol font family is 'symbol'", {
+  x <- xmlSVG({
+    plot(c(0,2), c(0,2), type = "n", axes = FALSE, xlab = "", ylab = "")
+    text(1, 1, expression(symbol("\042")))
+  })
+  text <- xml_find_all(x, ".//text")
+  expect_equal(xml_attr(text, "font-family"), c("symbol"))
+})
+


### PR DESCRIPTION
It should fix symbol display issue

    funplot <- function(){
      plot(c(0,4), c(5,1))
      text(1, 1, "universal", adj = 0); text(2.5, 1,  "\\042")
      text(3, 1, expression(symbol("\042")))
      text(1, 2, "existential", adj = 0); text(2.5, 2,  "\\044")
      text(3, 2, expression(symbol("\044")))
      text(1, 3, "suchthat", adj = 0); text(2.5, 3,  "\\047")
      text(3, 3, expression(symbol("\047")))
      text(1, 4, "therefore", adj = 0); text(2.5, 4,  "\\134")
      text(3, 4, expression(symbol("\134")))
      text(1, 5, "perpendicular", adj = 0); text(2.5, 5,  "\\136")
      text(3, 5, expression(symbol("\136")))
    }
    
    if (require("htmltools")) {
      htmlSVG(funplot())
    }
