### PR TITLE
add path() device function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,3 +29,7 @@
 * Works on Windows
 
 * Output no longer contains dummy `<desc>` element (#4)
+
+* The `path()` device function has been added to support the R plotting function
+  `polypath()`, and it also allows the `showtext` package to render
+  fonts correctly on the `devSVG()` device (#36)

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -1,0 +1,49 @@
+context("Paths")
+library(xml2)
+
+test_that("paths with winding fill mode", {
+  x <- xmlSVG({
+    plot.new()
+    polypath(c(.1, .1, .9, .9, NA, .2, .2, .8, .8),
+             c(.1, .9, .9, .1, NA, .2, .8, .8, .2),
+             col = rgb(0.5, 0.5, 0.5, 0.3), border = rgb(1, 0, 0, 0.3),
+             rule = "winding")
+  })
+  path <- xml_find_all(x, ".//path")
+  expect_equal(xml_attr(path, "fill-rule"), "nonzero")
+  expect_equal(xml_attr(path, "fill"), rgb(0.5, 0.5, 0.5))
+  expect_equal(xml_attr(path, "fill-opacity"), "0.30")
+  expect_equal(xml_attr(path, "stroke"), rgb(1, 0, 0))
+  expect_equal(xml_attr(path, "stroke-opacity"), "0.30")
+})
+
+test_that("paths with evenodd fill mode", {
+  x <- xmlSVG({
+    plot.new()
+    polypath(c(.1, .1, .9, .9, NA, .2, .2, .8, .8),
+             c(.1, .9, .9, .1, NA, .2, .8, .8, .2),
+             col = rgb(0.5, 0.5, 0.5, 0.3), border = rgb(1, 0, 0, 0.3),
+             rule = "evenodd")
+  })
+  path <- xml_find_all(x, ".//path")
+  expect_equal(xml_attr(path, "fill-rule"), "evenodd")
+  expect_equal(xml_attr(path, "fill"), rgb(0.5, 0.5, 0.5))
+  expect_equal(xml_attr(path, "fill-opacity"), "0.30")
+  expect_equal(xml_attr(path, "stroke"), rgb(1, 0, 0))
+  expect_equal(xml_attr(path, "stroke-opacity"), "0.30")
+})
+
+test_that("paths with no filling color", {
+  x <- xmlSVG({
+    plot.new()
+    polypath(c(.1, .1, .9, .9, NA, .2, .2, .8, .8),
+             c(.1, .9, .9, .1, NA, .2, .8, .8, .2),
+             col = NA, border = rgb(1, 0, 0, 0.3),
+             rule = "winding")
+  })
+  path <- xml_find_all(x, ".//path")
+  expect_equal(xml_attr(path, "fill-rule"), "nonzero")
+  expect_equal(xml_attr(path, "fill"), "none")
+  expect_equal(xml_attr(path, "stroke"), rgb(1, 0, 0))
+  expect_equal(xml_attr(path, "stroke-opacity"), "0.30")
+})


### PR DESCRIPTION
This PR adds the `path()` device function to `devSVG()`, so that it can support the R function `polypath()`, and the `showtext` package can render fonts properly on this device.