### PR TITLE
Support line end and line join styles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,3 +33,5 @@
 * The `path()` device function has been added to support the R plotting function
   `polypath()`, and it also allows the `showtext` package to render
   fonts correctly on the `devSVG()` device (#36)
+
+* Supports all line end and line join styles (#24)

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -257,10 +257,7 @@ void svg_path(double *x, double *y,
   write_attr_col(svgd->file, "fill", gc->fill);
 
   // Specify fill rule
-  if (winding)
-    fputs(" fill-rule='nonzero'", svgd->file);
-  else
-    fputs(" fill-rule='evenodd'", svgd->file);
+  write_attr_str(svgd->file, "fill-rule", winding ? "nonzero" : "evenodd");
 
   write_attrs_linetype(svgd->file, gc->lty, gc->lwd, gc->col);
 

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -82,7 +82,7 @@ inline void write_escaped(FILE* f, const char* text) {
   }
 }
 
-inline void write_attr_col(FILE* f, const char* attr, unsigned int col) {
+inline void write_attr_col(FILE* f, const char* attr, int col) {
   int alpha = R_ALPHA(col);
 
   if (col == NA_INTEGER || alpha == 0) {
@@ -388,7 +388,7 @@ void svg_raster(unsigned int *raster, int w, int h,
     height = -height;
 
   std::vector<unsigned int> raster_(w*h);
-  for (int i = 0 ; i < raster_.size(); ++i) {
+  for (std::vector<unsigned int>::size_type i = 0 ; i < raster_.size(); ++i) {
     raster_[i] = raster[i] ;
   }
 

--- a/tests/testthat/test-lines.R
+++ b/tests/testthat/test-lines.R
@@ -63,3 +63,40 @@ test_that("stroke-dasharray scales with lwd", {
   expect_equal(dash_array(lty = 2), c(4, 4))
   expect_equal(dash_array(lty = 2, lwd = 2), c(8, 8))
 })
+
+test_that("line end shapes", {
+  x1 <- xmlSVG({
+    plot.new()
+    lines(c(0.3, 0.7), c(0.5, 0.5), lwd = 15, lend = "round")
+  })
+  x2 <- xmlSVG({
+    plot.new()
+    lines(c(0.3, 0.7), c(0.5, 0.5), lwd = 15, lend = "butt")
+  })
+  x3 <- xmlSVG({
+    plot.new()
+    lines(c(0.3, 0.7), c(0.5, 0.5), lwd = 15, lend = "square")
+  })
+  expect_equal(xml_attr(xml_find_all(x1, ".//polyline"), "stroke-linecap"), "round")
+  expect_equal(xml_attr(xml_find_all(x2, ".//polyline"), "stroke-linecap"), NA_character_)
+  expect_equal(xml_attr(xml_find_all(x3, ".//polyline"), "stroke-linecap"), "square")
+})
+
+test_that("line join shapes", {
+  x1 <- xmlSVG({
+    plot.new()
+    lines(c(0.3, 0.5, 0.7), c(0.1, 0.9, 0.1), lwd = 15, ljoin = "round")
+  })
+  x2 <- xmlSVG({
+    plot.new()
+    lines(c(0.3, 0.5, 0.7), c(0.1, 0.9, 0.1), lwd = 15, ljoin = "mitre", lmitre = 10)
+  })
+  x3 <- xmlSVG({
+    plot.new()
+    lines(c(0.3, 0.5, 0.7), c(0.1, 0.9, 0.1), lwd = 15, ljoin = "bevel")
+  })
+  expect_equal(xml_attr(xml_find_all(x1, ".//polyline"), "stroke-linejoin"), "round")
+  expect_equal(xml_attr(xml_find_all(x2, ".//polyline"), "stroke-linejoin"), NA_character_)
+  expect_equal(xml_attr(xml_find_all(x2, ".//polyline"), "stroke-miterlimit"), "10.00")
+  expect_equal(xml_attr(xml_find_all(x3, ".//polyline"), "stroke-linejoin"), "bevel")
+})


### PR DESCRIPTION
This patch will generate line end and line join attributes when setting line styles, if the values are different from default. (https://github.com/mdecorde/RSvgDevice/issues/24)