### PR TITLE
Using <style> element and inline style attributes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,3 +35,6 @@
   fonts correctly on the `devSVG()` device (#36)
 
 * Supports all line end and line join styles (#24)
+
+* Styling properties such as `fill` and `stroke` are now specified in an inline
+  `style` attribute.

--- a/NEWS.md
+++ b/NEWS.md
@@ -38,3 +38,5 @@
 
 * Styling properties such as `fill` and `stroke` are now specified in an inline
   `style` attribute.
+
+* Default styling properties are specified in a global `<style>` element.

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -112,10 +112,10 @@ inline void write_style_end(FILE* f) {
 }
 
 // Writing style attributes related to colors
-inline void write_style_col(FILE* f, const char* attr, int col, bool head_space = true) {
+inline void write_style_col(FILE* f, const char* attr, int col, bool first = false) {
   int alpha = R_ALPHA(col);
 
-  fprintf(f, "%s", head_space ? " " : "");
+  fprintf(f, "%s", first ? "" : " ");
   if (col == NA_INTEGER || alpha == 0) {
     fprintf(f, "%s: none;", attr);
     return;
@@ -127,23 +127,23 @@ inline void write_style_col(FILE* f, const char* attr, int col, bool head_space 
 }
 
 // Writing style attributes whose values are double type
-inline void write_style_dbl(FILE* f, const char* attr, double value, bool head_space = true) {
-  fprintf(f, "%s", head_space ? " " : "");
+inline void write_style_dbl(FILE* f, const char* attr, double value, bool first = false) {
+  fprintf(f, "%s", first ? "" : " ");
   fprintf(f, "%s: %.2f;", attr, value);
 }
 
 // Writing style attributes whose values are strings
-inline void write_style_str(FILE* f, const char* attr, const char* value, bool head_space = true) {
-  fprintf(f, "%s", head_space ? " " : "");
+inline void write_style_str(FILE* f, const char* attr, const char* value, bool first = false) {
+  fprintf(f, "%s", first ? "" : " ");
   fprintf(f, "%s: %s;", attr, value);
 }
 
 // Writing style attributes related to line types
-inline void write_style_linetype(FILE* f, const pGEcontext gc, bool head_space = true) {
+inline void write_style_linetype(FILE* f, const pGEcontext gc, bool first = false) {
   int lty = gc->lty;
 
   // 1 lwd = 1/96", but units in rest of document are 1/72"
-  write_style_dbl(f, "stroke-width", gc->lwd / 96 * 72, head_space);
+  write_style_dbl(f, "stroke-width", gc->lwd / 96 * 72, first);
 
   // Default is "stroke: #000000;" as declared in <style>
   if (!is_black(gc->col))
@@ -270,7 +270,7 @@ void svg_new_page(const pGEcontext gc, pDevDesc dd) {
   fputs("<rect width='100%' height='100%'", svgd->file);
   if (is_filled(gc->fill)) {
     write_style_begin(svgd->file);
-    write_style_col(svgd->file, "fill", gc->fill, false);
+    write_style_col(svgd->file, "fill", gc->fill, true);
     write_style_end(svgd->file);
   }
   fputs("/>\n", svgd->file);
@@ -295,7 +295,7 @@ void svg_line(double x1, double y1, double x2, double y2,
     x1, y1, x2, y2);
 
   write_style_begin(svgd->file);
-  write_style_linetype(svgd->file, gc, false);
+  write_style_linetype(svgd->file, gc, true);
   write_style_end(svgd->file);
 
   fputs(" />\n", svgd->file);
@@ -313,7 +313,7 @@ void svg_poly(int n, double *x, double *y, int filled, const pGEcontext gc,
   fputs("'", svgd->file);
 
   write_style_begin(svgd->file);
-  write_style_linetype(svgd->file, gc, false);
+  write_style_linetype(svgd->file, gc, true);
   if (filled)
     write_style_col(svgd->file, "fill", gc->fill);
   write_style_end(svgd->file);
@@ -355,7 +355,7 @@ void svg_path(double *x, double *y,
 
   write_style_begin(svgd->file);
   // Specify fill rule
-  write_style_str(svgd->file, "fill-rule", winding ? "nonzero" : "evenodd", false);
+  write_style_str(svgd->file, "fill-rule", winding ? "nonzero" : "evenodd", true);
   if (is_filled(gc->fill))
     write_style_col(svgd->file, "fill", gc->fill);
   write_style_linetype(svgd->file, gc);
@@ -384,7 +384,7 @@ void svg_rect(double x0, double y0, double x1, double y1,
       fmin(x0, x1), fmin(y0, y1), fabs(x1 - x0), fabs(y1 - y0));
 
   write_style_begin(svgd->file);
-  write_style_linetype(svgd->file, gc, false);
+  write_style_linetype(svgd->file, gc, true);
   if (is_filled(gc->fill))
     write_style_col(svgd->file, "fill", gc->fill);
   write_style_end(svgd->file);
@@ -399,7 +399,7 @@ void svg_circle(double x, double y, double r, const pGEcontext gc,
   fprintf(svgd->file, "<circle cx='%.2f' cy='%.2f' r='%.2f'", x, y, r * 1.5);
 
   write_style_begin(svgd->file);
-  write_style_linetype(svgd->file, gc, false);
+  write_style_linetype(svgd->file, gc, true);
   if (is_filled(gc->fill))
     write_style_col(svgd->file, "fill", gc->fill);
   write_style_end(svgd->file);
@@ -422,7 +422,7 @@ void svg_text(double x, double y, const char *str, double rot,
   }
 
   write_style_begin(svgd->file);
-  write_style_dbl(svgd->file, "font-size", gc->cex * gc->ps, false);
+  write_style_dbl(svgd->file, "font-size", gc->cex * gc->ps, true);
   if (is_bold(gc->fontface))
     write_style_str(svgd->file, "font-weight", "bold");
   if (is_italic(gc->fontface))

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -249,7 +249,7 @@ void svg_new_page(const pGEcontext gc, pDevDesc dd) {
   fputs("    line, polyline, path, rect, circle {\n", svgd->file);
   fputs("      stroke-linecap: round;\n", svgd->file);
   fputs("      stroke-linejoin: round;\n", svgd->file);
-  fputs("      stroke-miterlimit: 10;\n", svgd->file);
+  fputs("      stroke-miterlimit: 10.00;\n", svgd->file);
   fputs("    }\n", svgd->file);
   fputs("  ]]></style>\n", svgd->file);
   fputs("</defs>\n", svgd->file);

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -105,16 +105,11 @@ inline void write_attr_str(FILE* f, const char* attr, const char* value) {
 
 inline void write_attrs_linetype(FILE* f, const pGEcontext gc) {
   int lty = gc->lty;
-  const double lwd = gc->lwd;
-  const int col = gc->col;
-  const int lend = gc->lend;
-  const int ljoin = gc->ljoin;
-  const double lmitre = gc->lmitre;
 
-  write_attr_col(f, "stroke", col);
+  write_attr_col(f, "stroke", gc->col);
 
   // 1 lwd = 1/96", but units in rest of document are 1/72"
-  write_attr_dbl(f, "stroke-width", lwd / 96 * 72);
+  write_attr_dbl(f, "stroke-width", gc->lwd / 96 * 72);
 
   // Set line pattern type
   switch (lty) {
@@ -125,7 +120,7 @@ inline void write_attrs_linetype(FILE* f, const pGEcontext gc) {
     // See comment in GraphicsEngine.h for how this works
     fputs(" stroke-dasharray='", f);
     for(int i = 0 ; i < 8 && lty & 15; i++) {
-      fprintf(f, "%i ", (int) lwd * (lty & 15));
+      fprintf(f, "%i ", (int) gc->lwd * (lty & 15));
       lty = lty >> 4;
     }
     fputs("'", f);
@@ -133,7 +128,7 @@ inline void write_attrs_linetype(FILE* f, const pGEcontext gc) {
   }
 
   // Set line end shape
-  switch(lend)
+  switch(gc->lend)
   {
   case GE_ROUND_CAP:
     write_attr_str(f, "stroke-linecap", "round");
@@ -147,7 +142,7 @@ inline void write_attrs_linetype(FILE* f, const pGEcontext gc) {
   }
 
   // Set line join shape
-  switch(ljoin)
+  switch(gc->ljoin)
   {
   case GE_ROUND_JOIN:
     write_attr_str(f, "stroke-linejoin", "round");
@@ -158,7 +153,7 @@ inline void write_attrs_linetype(FILE* f, const pGEcontext gc) {
   case GE_MITRE_JOIN: // We don't need to write "stroke-linejoin" attribute here,
                       // since the default is "miter". However, we do need to
                       // specify "stroke-miterlimit".
-    write_attr_dbl(f, "stroke-miterlimit", lmitre);
+    write_attr_dbl(f, "stroke-miterlimit", gc->lmitre);
   default:
     break;
   }

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -16,10 +16,10 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-#include "Rcpp.h"
+#include <Rcpp.h>
 #include <gdtools.h>
-#include <string.h>
-#include "R_ext/GraphicsEngine.h"
+#include <string>
+#include <R_ext/GraphicsEngine.h>
 
 // SVG device metadata
 class SVGDesc {

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -82,19 +82,6 @@ inline void write_escaped(FILE* f, const char* text) {
   }
 }
 
-inline void write_attr_col(FILE* f, const char* attr, int col) {
-  int alpha = R_ALPHA(col);
-
-  if (col == NA_INTEGER || alpha == 0) {
-    fprintf(f, " %s='none'", attr);
-    return;
-  } else {
-    fprintf(f, " %s='#%02X%02X%02X'", attr, R_RED(col), R_GREEN(col), R_BLUE(col));
-    if (alpha != 255)
-      fprintf(f, " %s-opacity='%0.2f'", attr, alpha / 255.0);
-  }
-}
-
 inline void write_attr_dbl(FILE* f, const char* attr, double value) {
   fprintf(f, " %s='%.2f'", attr, value);
 }
@@ -103,13 +90,53 @@ inline void write_attr_str(FILE* f, const char* attr, const char* value) {
   fprintf(f, " %s='%s'", attr, value);
 }
 
-inline void write_attrs_linetype(FILE* f, const pGEcontext gc) {
+
+
+// Beginning of writing style attributes
+inline void write_style_begin(FILE* f) {
+  fputs(" style='", f);
+}
+
+// End of writing style attributes
+inline void write_style_end(FILE* f) {
+  fputs("'", f);
+}
+
+// Writing style attributes related to colors
+inline void write_style_col(FILE* f, const char* attr, int col, bool head_space = true) {
+  int alpha = R_ALPHA(col);
+
+  fprintf(f, "%s", head_space ? " " : "");
+  if (col == NA_INTEGER || alpha == 0) {
+    fprintf(f, "%s: none;", attr);
+    return;
+  } else {
+    fprintf(f, "%s: #%02X%02X%02X;", attr, R_RED(col), R_GREEN(col), R_BLUE(col));
+    if (alpha != 255)
+      fprintf(f, " %s-opacity: %0.2f;", attr, alpha / 255.0);
+  }
+}
+
+// Writing style attributes whose values are double type
+inline void write_style_dbl(FILE* f, const char* attr, double value, bool head_space = true) {
+  fprintf(f, "%s", head_space ? " " : "");
+  fprintf(f, "%s: %.2f;", attr, value);
+}
+
+// Writing style attributes whose values are strings
+inline void write_style_str(FILE* f, const char* attr, const char* value, bool head_space = true) {
+  fprintf(f, "%s", head_space ? " " : "");
+  fprintf(f, "%s: %s;", attr, value);
+}
+
+// Writing style attributes related to line types
+inline void write_style_linetype(FILE* f, const pGEcontext gc, bool head_space = true) {
   int lty = gc->lty;
 
-  write_attr_col(f, "stroke", gc->col);
+  write_style_col(f, "stroke", gc->col, head_space);
 
   // 1 lwd = 1/96", but units in rest of document are 1/72"
-  write_attr_dbl(f, "stroke-width", gc->lwd / 96 * 72);
+  write_style_dbl(f, "stroke-width", gc->lwd / 96 * 72);
 
   // Set line pattern type
   switch (lty) {
@@ -118,25 +145,29 @@ inline void write_attrs_linetype(FILE* f, const pGEcontext gc) {
     break;
   default:
     // See comment in GraphicsEngine.h for how this works
-    fputs(" stroke-dasharray='", f);
-    for(int i = 0 ; i < 8 && lty & 15; i++) {
-      fprintf(f, "%i ", (int) gc->lwd * (lty & 15));
+    fputs(" stroke-dasharray: ", f);
+    // First number
+    fprintf(f, "%i", (int) gc->lwd * (lty & 15));
+    lty = lty >> 4;
+    // Remaining numbers
+    for(int i = 1 ; i < 8 && lty & 15; i++) {
+      fprintf(f, ",%i", (int) gc->lwd * (lty & 15));
       lty = lty >> 4;
     }
-    fputs("'", f);
+    fputs(";", f);
     break;
   }
 
   // Set line end shape
   switch(gc->lend)
   {
-  case GE_ROUND_CAP:
-    write_attr_str(f, "stroke-linecap", "round");
+  case GE_ROUND_CAP: // declared to be default in <style>
+    break;
+  case GE_BUTT_CAP:
+    write_style_str(f, "stroke-linecap", "butt");
     break;
   case GE_SQUARE_CAP:
-    write_attr_str(f, "stroke-linecap", "square");
-    break;
-  case GE_BUTT_CAP: // doing nothing, default is butt
+    write_style_str(f, "stroke-linecap", "square");
     break;
   default:
     break;
@@ -145,18 +176,15 @@ inline void write_attrs_linetype(FILE* f, const pGEcontext gc) {
   // Set line join shape
   switch(gc->ljoin)
   {
-  case GE_ROUND_JOIN:
-    write_attr_str(f, "stroke-linejoin", "round");
+  case GE_ROUND_JOIN: // declared to be default in <style>
     break;
   case GE_BEVEL_JOIN:
-    write_attr_str(f, "stroke-linejoin", "bevel");
+    write_style_str(f, "stroke-linejoin", "bevel");
     break;
-  case GE_MITRE_JOIN: // We don't need to write "stroke-linejoin" attribute here,
-                      // since the default is "miter". However, we do need to
-                      // specify "stroke-miterlimit" when the value is not 4
-                      // (the SVG default).
-    if (gc->lmitre != 4.0)
-      write_attr_dbl(f, "stroke-miterlimit", gc->lmitre);
+  case GE_MITRE_JOIN:
+    write_style_str(f, "stroke-linejoin", "miter");
+    if (std::abs(gc->lmitre - 10.0) > 1e-3) // 10 is declared to be the default in <style>
+      write_style_dbl(f, "stroke-miterlimit", gc->lmitre);
     break;
   default:
     break;
@@ -215,8 +243,21 @@ void svg_new_page(const pGEcontext gc, pDevDesc dd) {
 
   fprintf(svgd->file, " viewBox='0 0 %.2f %.2f'>\n", dd->right, dd->bottom);
 
+  // Setting default styles
+  fputs("<defs>\n", svgd->file);
+  fputs("  <style type='text/css'><![CDATA[\n", svgd->file);
+  fputs("    line, polyline, path, rect, circle {\n", svgd->file);
+  fputs("      stroke-linecap: round;\n", svgd->file);
+  fputs("      stroke-linejoin: round;\n", svgd->file);
+  fputs("      stroke-miterlimit: 10;\n", svgd->file);
+  fputs("    }\n", svgd->file);
+  fputs("  ]]></style>\n", svgd->file);
+  fputs("</defs>\n", svgd->file);
+
   fputs("<rect width='100%' height='100%'", svgd->file);
-  write_attr_col(svgd->file, "fill", gc->fill);
+  write_style_begin(svgd->file);
+  write_style_col(svgd->file, "fill", gc->fill, false);
+  write_style_end(svgd->file);
   fputs("/>\n", svgd->file);
 
   svgd->pageno++;
@@ -238,7 +279,10 @@ void svg_line(double x1, double y1, double x2, double y2,
   fprintf(svgd->file, "<line x1='%.2f' y1='%.2f' x2='%.2f' y2='%.2f'",
     x1, y1, x2, y2);
 
-  write_attrs_linetype(svgd->file, gc);
+  write_style_begin(svgd->file);
+  write_style_linetype(svgd->file, gc, false);
+  write_style_end(svgd->file);
+
   fputs(" />\n", svgd->file);
 }
 
@@ -253,8 +297,10 @@ void svg_poly(int n, double *x, double *y, int filled, const pGEcontext gc,
   }
   fputs("'", svgd->file);
 
-  write_attr_col(svgd->file, "fill", filled ? gc->fill : NA_INTEGER);
-  write_attrs_linetype(svgd->file, gc);
+  write_style_begin(svgd->file);
+  write_style_col(svgd->file, "fill", filled ? gc->fill : NA_INTEGER, false);
+  write_style_linetype(svgd->file, gc);
+  write_style_end(svgd->file);
 
   fputs(" />\n", svgd->file);
 }
@@ -291,12 +337,12 @@ void svg_path(double *x, double *y,
   // Finish path data
   fputs("'", svgd->file);
 
-  write_attr_col(svgd->file, "fill", gc->fill);
-
+  write_style_begin(svgd->file);
+  write_style_col(svgd->file, "fill", gc->fill, false);
   // Specify fill rule
-  write_attr_str(svgd->file, "fill-rule", winding ? "nonzero" : "evenodd");
-
-  write_attrs_linetype(svgd->file, gc);
+  write_style_str(svgd->file, "fill-rule", winding ? "nonzero" : "evenodd");
+  write_style_linetype(svgd->file, gc);
+  write_style_end(svgd->file);
 
   fputs(" />\n", svgd->file);
 }
@@ -320,8 +366,11 @@ void svg_rect(double x0, double y0, double x1, double y1,
       "<rect x='%.2f' y='%.2f' width='%.2f' height='%.2f'",
       fmin(x0, x1), fmin(y0, y1), fabs(x1 - x0), fabs(y1 - y0));
 
-  write_attr_col(svgd->file, "fill", gc->fill);
-  write_attrs_linetype(svgd->file, gc);
+  write_style_begin(svgd->file);
+  write_style_col(svgd->file, "fill", gc->fill, false);
+  write_style_linetype(svgd->file, gc);
+  write_style_end(svgd->file);
+
   fputs(" />\n", svgd->file);
 }
 
@@ -330,8 +379,11 @@ void svg_circle(double x, double y, double r, const pGEcontext gc,
   SVGDesc *svgd = (SVGDesc*) dd->deviceSpecific;
 
   fprintf(svgd->file, "<circle cx='%.2f' cy='%.2f' r='%.2f'", x, y, r * 1.5);
-  write_attr_col(svgd->file, "fill", gc->fill);
-  write_attrs_linetype(svgd->file, gc);
+  write_style_begin(svgd->file);
+  write_style_col(svgd->file, "fill", gc->fill, false);
+  write_style_linetype(svgd->file, gc);
+  write_style_end(svgd->file);
+
   fputs(" />\n", svgd->file);
 }
 
@@ -349,16 +401,18 @@ void svg_text(double x, double y, const char *str, double rot,
       -1.0 * rot);
   }
 
-  write_attr_dbl(svgd->file, "font-size", gc->cex * gc->ps);
+  write_style_begin(svgd->file);
+  write_style_dbl(svgd->file, "font-size", gc->cex * gc->ps, false);
   if (is_bold(gc->fontface))
-    write_attr_str(svgd->file, "font-weight", "bold");
+    write_style_str(svgd->file, "font-weight", "bold");
   if (is_italic(gc->fontface))
-    write_attr_str(svgd->file, "font-style", "italic");
+    write_style_str(svgd->file, "font-style", "italic");
   if (gc->col != -16777216) // black
-    write_attr_col(svgd->file, "fill", gc->col);
+    write_style_col(svgd->file, "fill", gc->col);
 
   std::string font = fontname(gc->fontfamily, gc->fontface);
-  write_attr_str(svgd->file, "font-family", font.c_str());
+  write_style_str(svgd->file, "font-family", font.c_str());
+  write_style_end(svgd->file);
 
   fputs(">", svgd->file);
 
@@ -500,4 +554,3 @@ bool devSVG_(std::string file, std::string bg_, int width, int height,
 
   return true;
 }
-

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -137,6 +137,7 @@ inline void write_attrs_linetype(FILE* f, const pGEcontext gc) {
     write_attr_str(f, "stroke-linecap", "square");
     break;
   case GE_BUTT_CAP: // doing nothing, default is butt
+    break;
   default:
     break;
   }
@@ -152,8 +153,11 @@ inline void write_attrs_linetype(FILE* f, const pGEcontext gc) {
     break;
   case GE_MITRE_JOIN: // We don't need to write "stroke-linejoin" attribute here,
                       // since the default is "miter". However, we do need to
-                      // specify "stroke-miterlimit".
-    write_attr_dbl(f, "stroke-miterlimit", gc->lmitre);
+                      // specify "stroke-miterlimit" when the value is not 4
+                      // (the SVG default).
+    if (gc->lmitre != 4.0)
+      write_attr_dbl(f, "stroke-miterlimit", gc->lmitre);
+    break;
   default:
     break;
   }

--- a/tests/testthat/test-devSVG.R
+++ b/tests/testthat/test-devSVG.R
@@ -21,6 +21,16 @@ test_that("default background respects par", {
   expect_equal(style_attr(xml_find_one(x, ".//rect"), "fill"), rgb(1, 0, 0))
 })
 
+test_that("no background", {
+  x <- xmlSVG({
+    par(bg = NA)
+    plot.new()
+  })
+  style <- xml_text(xml_find_one(x, "//style"))
+  expect_match(style, "fill: none;")
+  expect_equal(style_attr(xml_find_one(x, ".//rect"), "fill"), NA_character_)
+})
+
 test_that("can only have one page", {
   devSVG(tempfile())
   on.exit(dev.off())

--- a/tests/testthat/test-devSVG.R
+++ b/tests/testthat/test-devSVG.R
@@ -1,9 +1,16 @@
 context("devSVG")
 library(xml2)
 
+style_attr <- function(nodes, attr) {
+  style <- xml_attr(nodes, "style")
+  ifelse(grepl(sprintf("%s: [^;]*;", attr), style),
+         gsub(sprintf(".*%s: ([^;]*);.*", attr), "\\1", style),
+         NA_character_)
+}
+
 test_that("adds default background", {
   x <- xmlSVG(plot.new())
-  expect_equal(xml_attr(xml_find_one(x, ".//rect"), "fill"), "#FFFFFF")
+  expect_equal(style_attr(xml_find_one(x, ".//rect"), "fill"), "#FFFFFF")
 })
 
 test_that("default background respects par", {
@@ -11,7 +18,7 @@ test_that("default background respects par", {
     par(bg = "red")
     plot.new()
   })
-  expect_equal(xml_attr(xml_find_one(x, ".//rect"), "fill"), rgb(1, 0, 0))
+  expect_equal(style_attr(xml_find_one(x, ".//rect"), "fill"), rgb(1, 0, 0))
 })
 
 test_that("can only have one page", {

--- a/tests/testthat/test-lines.R
+++ b/tests/testthat/test-lines.R
@@ -13,6 +13,8 @@ test_that("segments don't have fill", {
     plot.new()
     segments(0.5, 0.5, 1, 1)
   })
+  style <- xml_text(xml_find_one(x, "//style"))
+  expect_match(style, "fill: none;")
   expect_equal(style_attr(xml_find_one(x, ".//line"), "fill"), NA_character_)
 })
 
@@ -21,7 +23,7 @@ test_that("lines don't have fill", {
     plot.new()
     lines(c(0.5, 1, 0.5), c(0.5, 1, 1))
   })
-  expect_equal(style_attr(xml_find_one(x, ".//polyline"), "fill"), "none")
+  expect_equal(style_attr(xml_find_one(x, ".//polyline"), "fill"), NA_character_)
 })
 
 test_that("polygons do have fill", {

--- a/tests/testthat/test-lines.R
+++ b/tests/testthat/test-lines.R
@@ -36,6 +36,16 @@ test_that("polygons do have fill", {
   expect_equal(style_attr(polygon, "stroke"), rgb(0, 0, 1))
 })
 
+test_that("polygons without border", {
+  x <- xmlSVG({
+    plot.new()
+    polygon(c(0.5, 1, 0.5), c(0.5, 1, 1), col = "red", border = NA)
+  })
+  polygon <- xml_find_one(x, ".//polyline")
+  expect_equal(style_attr(polygon, "fill"), rgb(1, 0, 0))
+  expect_equal(style_attr(polygon, "stroke"), "none")
+})
+
 test_that("last point of polygon joined to first point", {
   x <- xmlSVG({
     plot.new()

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -48,9 +48,12 @@ test_that("paths with no filling color", {
              col = NA, border = rgb(1, 0, 0, 0.3),
              rule = "winding")
   })
+  style <- xml_text(xml_find_one(x, "//style"))
+  expect_match(style, "fill: none;")
+
   path <- xml_find_one(x, ".//path")
   expect_equal(style_attr(path, "fill-rule"), "nonzero")
-  expect_equal(style_attr(path, "fill"), "none")
+  expect_equal(style_attr(path, "fill"), NA_character_)
   expect_equal(style_attr(path, "stroke"), rgb(1, 0, 0))
   expect_equal(style_attr(path, "stroke-opacity"), "0.30")
 })

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -1,6 +1,13 @@
 context("Paths")
 library(xml2)
 
+style_attr <- function(nodes, attr) {
+  style <- xml_attr(nodes, "style")
+  ifelse(grepl(sprintf("%s: [^;]*;", attr), style),
+         gsub(sprintf(".*%s: ([^;]*);.*", attr), "\\1", style),
+         NA_character_)
+}
+
 test_that("paths with winding fill mode", {
   x <- xmlSVG({
     plot.new()
@@ -9,12 +16,12 @@ test_that("paths with winding fill mode", {
              col = rgb(0.5, 0.5, 0.5, 0.3), border = rgb(1, 0, 0, 0.3),
              rule = "winding")
   })
-  path <- xml_find_all(x, ".//path")
-  expect_equal(xml_attr(path, "fill-rule"), "nonzero")
-  expect_equal(xml_attr(path, "fill"), rgb(0.5, 0.5, 0.5))
-  expect_equal(xml_attr(path, "fill-opacity"), "0.30")
-  expect_equal(xml_attr(path, "stroke"), rgb(1, 0, 0))
-  expect_equal(xml_attr(path, "stroke-opacity"), "0.30")
+  path <- xml_find_one(x, ".//path")
+  expect_equal(style_attr(path, "fill-rule"), "nonzero")
+  expect_equal(style_attr(path, "fill"), rgb(0.5, 0.5, 0.5))
+  expect_equal(style_attr(path, "fill-opacity"), "0.30")
+  expect_equal(style_attr(path, "stroke"), rgb(1, 0, 0))
+  expect_equal(style_attr(path, "stroke-opacity"), "0.30")
 })
 
 test_that("paths with evenodd fill mode", {
@@ -25,12 +32,12 @@ test_that("paths with evenodd fill mode", {
              col = rgb(0.5, 0.5, 0.5, 0.3), border = rgb(1, 0, 0, 0.3),
              rule = "evenodd")
   })
-  path <- xml_find_all(x, ".//path")
-  expect_equal(xml_attr(path, "fill-rule"), "evenodd")
-  expect_equal(xml_attr(path, "fill"), rgb(0.5, 0.5, 0.5))
-  expect_equal(xml_attr(path, "fill-opacity"), "0.30")
-  expect_equal(xml_attr(path, "stroke"), rgb(1, 0, 0))
-  expect_equal(xml_attr(path, "stroke-opacity"), "0.30")
+  path <- xml_find_one(x, ".//path")
+  expect_equal(style_attr(path, "fill-rule"), "evenodd")
+  expect_equal(style_attr(path, "fill"), rgb(0.5, 0.5, 0.5))
+  expect_equal(style_attr(path, "fill-opacity"), "0.30")
+  expect_equal(style_attr(path, "stroke"), rgb(1, 0, 0))
+  expect_equal(style_attr(path, "stroke-opacity"), "0.30")
 })
 
 test_that("paths with no filling color", {
@@ -41,9 +48,9 @@ test_that("paths with no filling color", {
              col = NA, border = rgb(1, 0, 0, 0.3),
              rule = "winding")
   })
-  path <- xml_find_all(x, ".//path")
-  expect_equal(xml_attr(path, "fill-rule"), "nonzero")
-  expect_equal(xml_attr(path, "fill"), "none")
-  expect_equal(xml_attr(path, "stroke"), rgb(1, 0, 0))
-  expect_equal(xml_attr(path, "stroke-opacity"), "0.30")
+  path <- xml_find_one(x, ".//path")
+  expect_equal(style_attr(path, "fill-rule"), "nonzero")
+  expect_equal(style_attr(path, "fill"), "none")
+  expect_equal(style_attr(path, "stroke"), rgb(1, 0, 0))
+  expect_equal(style_attr(path, "stroke-opacity"), "0.30")
 })

--- a/tests/testthat/test-points.R
+++ b/tests/testthat/test-points.R
@@ -1,4 +1,12 @@
 context("Points")
+library(xml2)
+
+style_attr <- function(nodes, attr) {
+  style <- xml_attr(nodes, "style")
+  ifelse(grepl(sprintf("%s: [^;]*;", attr), style),
+         gsub(sprintf(".*%s: ([^;]*);.*", attr), "\\1", style),
+         NA_character_)
+}
 
 test_that("points are given stroke and fill", {
   x <- xmlSVG({
@@ -6,8 +14,8 @@ test_that("points are given stroke and fill", {
     points(0.5, 0.5, pch = 21, col = "red", bg = "blue", cex = 20)
   })
   circle <- xml_find_all(x, ".//circle")
-  expect_equal(xml_attr(circle, "stroke"), rgb(1, 0, 0))
-  expect_equal(xml_attr(circle, "fill"), rgb(0, 0, 1))
+  expect_equal(style_attr(circle, "stroke"), rgb(1, 0, 0))
+  expect_equal(style_attr(circle, "fill"), rgb(0, 0, 1))
 })
 
 test_that("points get alpha stroke and fill given stroke and fill", {
@@ -16,10 +24,10 @@ test_that("points get alpha stroke and fill given stroke and fill", {
     points(0.5, 0.5, pch = 21, col = rgb(1, 0, 0, 0.1), bg = rgb(0, 0, 1, 0.1), cex = 20)
   })
   circle <- xml_find_all(x, ".//circle")
-  expect_equal(xml_attr(circle, "stroke"), rgb(1, 0, 0))
-  expect_equal(xml_attr(circle, "stroke-opacity"), "0.10")
-  expect_equal(xml_attr(circle, "fill"), rgb(0, 0, 1))
-  expect_equal(xml_attr(circle, "fill-opacity"), "0.10")
+  expect_equal(style_attr(circle, "stroke"), rgb(1, 0, 0))
+  expect_equal(style_attr(circle, "stroke-opacity"), "0.10")
+  expect_equal(style_attr(circle, "fill"), rgb(0, 0, 1))
+  expect_equal(style_attr(circle, "fill-opacity"), "0.10")
 })
 
 test_that("points are given stroke and fill", {
@@ -28,6 +36,6 @@ test_that("points are given stroke and fill", {
     points(0.5, 0.5, pch = 21, col = "red", bg = NA, cex = 20)
   })
   circle <- xml_find_all(x, ".//circle")
-  expect_equal(xml_attr(circle, "fill"), "none")
+  expect_equal(style_attr(circle, "fill"), "none")
 })
 

--- a/tests/testthat/test-points.R
+++ b/tests/testthat/test-points.R
@@ -35,7 +35,10 @@ test_that("points are given stroke and fill", {
     plot.new()
     points(0.5, 0.5, pch = 21, col = "red", bg = NA, cex = 20)
   })
+  style <- xml_text(xml_find_one(x, "//style"))
+  expect_match(style, "fill: none;")
+
   circle <- xml_find_all(x, ".//circle")
-  expect_equal(style_attr(circle, "fill"), "none")
+  expect_equal(style_attr(circle, "fill"), NA_character_)
 })
 

--- a/tests/testthat/test-rect.R
+++ b/tests/testthat/test-rect.R
@@ -1,4 +1,12 @@
 context("Rect")
+library(xml2)
+
+style_attr <- function(nodes, attr) {
+  style <- xml_attr(nodes, "style")
+  ifelse(grepl(sprintf("%s: [^;]*;", attr), style),
+         gsub(sprintf(".*%s: ([^;]*);.*", attr), "\\1", style),
+         NA_character_)
+}
 
 test_that("rects equivalent regardless of direction", {
   x1 <- xmlSVG({

--- a/tests/testthat/test-rect.R
+++ b/tests/testthat/test-rect.R
@@ -1,4 +1,4 @@
-context("rect")
+context("Rect")
 
 test_that("rects equivalent regardless of direction", {
   x1 <- xmlSVG({
@@ -16,3 +16,12 @@ test_that("rects equivalent regardless of direction", {
   expect_equal(rect1, rect2)
 })
 
+test_that("fill and stroke colors", {
+  x <- xmlSVG({
+    plot.new()
+    rect(0.2, 0.2, 0.8, 0.8, col = "blue", border = "red")
+  })
+  rectangle <- xml_find_all(x, ".//rect")[[2]]
+  expect_equal(style_attr(rectangle, "fill"), rgb(0, 0, 1))
+  expect_equal(style_attr(rectangle, "stroke"), rgb(1, 0, 0))
+})

--- a/tests/testthat/test-text.R
+++ b/tests/testthat/test-text.R
@@ -1,5 +1,12 @@
-context("text")
+context("Text")
 library(xml2)
+
+style_attr <- function(nodes, attr) {
+  style <- xml_attr(nodes, "style")
+  ifelse(grepl(sprintf("%s: [^;]*;", attr), style),
+         gsub(sprintf(".*%s: ([^;]*);.*", attr), "\\1", style),
+         NA_character_)
+}
 
 test_that("par(cex) affects strwidth", {
   devSVG(tempfile())
@@ -50,7 +57,7 @@ test_that("special characters are escaped", {
   })
   # xml_text unescapes for us - this still tests that the
   # file parses, which it wouldn't otherwise
-  expect_equal(xml_attr(xml_find_one(x, ".//text"), "fill"), "#113399")
+  expect_equal(style_attr(xml_find_one(x, ".//text"), "fill"), "#113399")
 })
 
 test_that("default point size is 12", {
@@ -58,7 +65,7 @@ test_that("default point size is 12", {
     plot.new()
     text(0.5, 0.5, "a")
   })
-  expect_equal(xml_attr(xml_find_one(x, ".//text"), "font-size"), "12.00")
+  expect_equal(style_attr(xml_find_one(x, ".//text"), "font-size"), "12.00")
 })
 
 test_that("cex generates fractional font sizes", {
@@ -66,7 +73,7 @@ test_that("cex generates fractional font sizes", {
     plot.new()
     text(0.5, 0.5, "a", cex = 0.1)
   })
-  expect_equal(xml_attr(xml_find_one(x, ".//text"), "font-size"), "1.20")
+  expect_equal(style_attr(xml_find_one(x, ".//text"), "font-size"), "1.20")
 })
 
 test_that("font sets weight/style", {
@@ -75,8 +82,8 @@ test_that("font sets weight/style", {
     text(0.5, seq(0.9, 0.1, length = 4), "a", font = 1:4)
   })
   text <- xml_find_all(x, ".//text")
-  expect_equal(xml_attr(text, "font-weight"), c(NA, "bold", NA, "bold"))
-  expect_equal(xml_attr(text, "font-style"), c(NA, NA, "italic", "italic"))
+  expect_equal(style_attr(text, "font-weight"), c(NA, "bold", NA, "bold"))
+  expect_equal(style_attr(text, "font-style"), c(NA, NA, "italic", "italic"))
 })
 
 test_that("font sets weight/style", {
@@ -87,7 +94,7 @@ test_that("font sets weight/style", {
     text(0.5, 0.9, "a", family = "mono")
   })
   text <- xml_find_all(x, ".//text")
-  expect_equal(xml_attr(text, "font-family"), c("Times New Roman", "Arial", "courier"))
+  expect_equal(style_attr(text, "font-family"), c("Times New Roman", "Arial", "courier"))
 })
 
 test_that("a symbol has width greater than 0", {
@@ -104,6 +111,6 @@ test_that("symbol font family is 'symbol'", {
     text(1, 1, expression(symbol("\042")))
   })
   text <- xml_find_all(x, ".//text")
-  expect_equal(xml_attr(text, "font-family"), c("symbol"))
+  expect_equal(style_attr(text, "font-family"), c("symbol"))
 })
 


### PR DESCRIPTION
A `<style>` element will be added when `svg_new_page()` is called. This globally defines several default attributes, including fill color, stroke color, line end shape, line join shape etc.

Styling properties for a single shape object will be put in an inline `style` attribute, which override the global ones in `<style>` when necessary. These properties are written only when they are different from the default values. For example, the following R code
```r
plot.new()
set.seed(123)
symbols(runif(4), runif(4), circles = rep(0.05, 4), inches = FALSE, add = TRUE,
        fg  = c(1, 2, 1, 2),
        bg  = c(1, 1, NA, NA))
```
will generate SVG file
```svg
<?xml version='1.0' encoding='UTF-8' ?>
<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
<defs>
  <style type='text/css'><![CDATA[
    line, polyline, path, rect, circle {
      fill: none;
      stroke: #000000;
      stroke-linecap: round;
      stroke-linejoin: round;
      stroke-miterlimit: 10.00;
    }
  ]]></style>
</defs>
<rect width='100%' height='100%' style='fill: #FFFFFF;'/>
<circle cx='631.63' cy='368.03' r='43.80' style='stroke-width: 0.75; fill: #000000;' />
<circle cx='109.00' cy='162.40' r='43.80' style='stroke-width: 0.75; stroke: #FF0000; fill: #000000;' />
<circle cx='390.81' cy='318.18' r='43.80' style='stroke-width: 0.75;' />
<circle cx='603.57' cy='123.51' r='43.80' style='stroke-width: 0.75; stroke: #FF0000;' />
</svg>
```
This strategy in general could further reduce the file size of plots. Using the benchmark example in README, the file size is now reduced from ~93K to ~73K.